### PR TITLE
feature: use "Do" return value. Overlap "Return".

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -203,7 +203,7 @@ func (c *Call) dropPrereqs() (preReqs []*Call) {
 	return
 }
 
-func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
+func (c *Call) call(args []interface{}) (action func() []interface {}) {
 	c.numCalls++
 
 	// Actions
@@ -218,22 +218,31 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 				doArgs[i] = reflect.Zero(ft.In(i))
 			}
 		}
-		action = func() { c.doFunc.Call(doArgs) }
+		action = func() []interface {} {
+			result := c.doFunc.Call(doArgs)
+			rets := make([]interface{}, len(result))
+			for i:=0; i<len(result); i++{
+				rets[i] = result[i].Interface()
+			}
+			return rets
+		}
+	} else {
+		action = func() []interface {} {
+			rets := c.rets
+			if  rets == nil {
+				// Synthesize the zero value for each of the return args' types.
+				mt := c.methodType()
+				rets = make([]interface{}, mt.NumOut())
+				for i := 0; i < mt.NumOut(); i++ {
+					rets[i] = reflect.Zero(mt.Out(i)).Interface()
+				}
+			}
+			return rets
+		}
 	}
 	for n, v := range c.setArgs {
 		reflect.ValueOf(args[n]).Elem().Set(v)
 	}
-
-	rets = c.rets
-	if rets == nil {
-		// Synthesize the zero value for each of the return args' types.
-		mt := c.methodType()
-		rets = make([]interface{}, mt.NumOut())
-		for i := 0; i < mt.NumOut(); i++ {
-			rets[i] = reflect.Zero(mt.Out(i)).Interface()
-		}
-	}
-
 	return
 }
 

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -126,7 +126,7 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 		ctrl.expectedCalls.Remove(preReqCall)
 	}
 
-	rets, action := expected.call(args)
+	action := expected.call(args)
 	if expected.exhausted() {
 		ctrl.expectedCalls.Remove(expected)
 	}
@@ -137,11 +137,8 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	// here we add a deferred Lock to balance it.
 	ctrl.mu.Unlock()
 	defer ctrl.mu.Lock()
-	if action != nil {
-		action()
-	}
 
-	return rets
+	return action()
 }
 
 func (ctrl *Controller) Finish() {


### PR DESCRIPTION
Sometimes need to return a different value for different input arguments. I think it would be more convenient.

Example:

```
func TestRead(t *testing.T) {
    mockCtrl := gomock.NewController(t)
    defer mockCtrl.Finish()
    mockObj := mock_io.NewMockReadWriteCloser(mockCtrl)
    do := func(d []byte) (int, error) {
        return len(d), nil
    }
    mockObj.EXPECT().Read(gomock.Any()).AnyTimes().Do(do)
    fmt.Println(mockObj.Read([]byte{0x1}))
    fmt.Println(mockObj.Read([]byte{0x1, 0x1, 0x1}))
}
```

```
1 <nil>
3 <nil>
```
